### PR TITLE
Fixing bug - Appnexus API request fails if binary data is uploaded.

### DIFF
--- a/nexusadspy/client.py
+++ b/nexusadspy/client.py
@@ -125,7 +125,6 @@ class AppnexusClient():
                               sec_sleep=2., max_failures=100,
                               get_field=None):
 
-        data = json.dumps(data)
         no_fail = 0
         while True:
             r = requests.request(method, url, params=params, data=data, headers=headers)

--- a/nexusadspy/client.py
+++ b/nexusadspy/client.py
@@ -125,6 +125,8 @@ class AppnexusClient():
                               sec_sleep=2., max_failures=100,
                               get_field=None):
 
+        if isinstance(data, dict):
+            data = json.dumps(data)
         no_fail = 0
         while True:
             r = requests.request(method, url, params=params, data=data, headers=headers)


### PR DESCRIPTION
`json.dumps` does not work with byte stream.