### PR TITLE
Fix reports download bug

### DIFF
--- a/nexusadspy/client.py
+++ b/nexusadspy/client.py
@@ -98,8 +98,10 @@ class AppnexusClient():
             r_code, r = self._do_authenticated_request(url, method, params=params,
                                                        data=data, headers=headers,
                                                        get_field=get_field)
+
             output_term = get_field or r['dbg_info']['output_term']
-            output = r[output_term]
+            output = r.get(output_term, r)
+
             if isinstance(output, list):
                 res[output_term] += output  # assume list of dictionaries
             else:

--- a/nexusadspy/report.py
+++ b/nexusadspy/report.py
@@ -95,8 +95,11 @@ class AppnexusReport():
         response = {}
         for retry in range(self.max_retries):
             data = {'id': report_id}
-            response = client.request(self.endpoint, 'GET', data=data, get_field='execution_status')[0]
-            if response['execution_status'] == 'ready':
+            response = client.request(self.endpoint, 'GET', data=data)[0]
+            execution_status = response.get(
+                'execution_status', response['reports'][0]['execution_status']
+            )
+            if execution_status == 'ready':
                 response = client.request(self.endpoint, 'GET', data=data, get_field='report')
                 break
             else:


### PR DESCRIPTION
If there are existing reports with 'execution status' set to 'ready' when you make a fresh report request, APN will stack them in a "reports" field and removes the previously existing "execution status" field in the request since it will not belong to just one report anymore.

This fix checks for that field and returns the status for latest report request, assuming that's the one you've just made.
